### PR TITLE
Add static URIs

### DIFF
--- a/config.json
+++ b/config.json
@@ -34,7 +34,8 @@
                     "items": [
                         {
                             "title": "Overview",
-                            "content": "docs/ActionBatches.md"
+                            "content": "docs/ActionBatches.md",
+                            "uri": "action-batches-overview"
                         },
                         {
                             "title": "Supported Resources",
@@ -72,7 +73,8 @@
                     "items": [
                         {
                             "title": "Overview",
-                            "content": "docs/UserAgents.md"
+                            "content": "docs/UserAgents.md",
+                            "uri": "user-agents-overview"
                         }
                     ]
                 },


### PR DESCRIPTION
This will fix the URL of the docs so that https://developer.cisco.com/meraki/api-v1/#!overview links to the main API Reference Overview page not the Action Batches or User Agents overview pages.